### PR TITLE
Custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # UWorld Batch Unsuspend
-Anki add-on to suspend multiple cards at once based on UWorld question ID. <br>
+Anki add-on to unsuspend multiple cards at once based on UWorld question ID for Step 1 v11 and Step 2 v11. <br>
 Direct link to this add-on can be found [here](https://ankiweb.net/shared/info/899971795).
 
 ![uworld_anki_1](https://github.com/Osborw/uworld-batch-unsuspend/assets/32249906/f8ae1425-0aeb-4e14-9d41-7b1f83baafe2)
@@ -21,4 +21,4 @@ And if you're inclined to do so, feel free to create any new PRs with changes an
 
 ## Thanks :)
 
-If you found this helpful, I'd appreciate a quick rating on AnkiWeb or Star this repo on Github.
+If you found this helpful, I'd appreciate a rating on AnkiWeb or Star this repo on Github. It goes a long way!

--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,6 @@ osceDialog = dialog.OsceDialog()
 def main():
     osceDialog.show()
 
-action = QAction("UWorld Batch Unsuspend", mw)
+action = QAction("-Test- UWorld Batch Unsuspend", mw)
 qconnect(action.triggered, main)
 mw.form.menuTools.addAction(action)

--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,6 @@ osceDialog = dialog.OsceDialog()
 def main():
     osceDialog.show()
 
-action = QAction("-Test- UWorld Batch Unsuspend", mw)
+action = QAction("UWorld Batch Unsuspend", mw)
 qconnect(action.triggered, main)
 mw.form.menuTools.addAction(action)

--- a/config.json
+++ b/config.json
@@ -1,0 +1,1 @@
+{"lastUsedTagPrefix": "none"}

--- a/dialog.py
+++ b/dialog.py
@@ -8,9 +8,17 @@ class OsceDialog(QDialog):
         self.setWindowTitle("UWorld Batch Unsuspend")
         self.layout = QVBoxLayout()
 
-        label1 = QLabel("Directions:\nEnter tags below. Each tag should be one line.\n\nPlease give Anki a few seconds to process.")
-        self.tags = QPlainTextEdit()
+        label1 = QLabel("Directions:\nEnter tags below. Each tag should be one line.\n\nPlease give Anki a few seconds to process.\n")
         self.layout.addWidget(label1)
+
+        label2 = QLabel("Choose which version of cards you will be unsuspending.")
+        self.layout.addWidget(label2)
+        self.stepVersion = QComboBox() 
+        self.stepVersion.insertItems(0, list(tagLogic.tagPrefixDict.keys()))
+        self.stepVersion.setCurrentIndex(tagLogic.getLastUsedTagPrefixIndex())
+        self.layout.addWidget(self.stepVersion)
+
+        self.tags = QPlainTextEdit()
         self.layout.addWidget(self.tags)
 
         self.button = QPushButton("Unsuspend")
@@ -22,14 +30,17 @@ class OsceDialog(QDialog):
     def unsuspendCardsByTags(self):
 
         tagsList = self.tags.toPlainText().strip().split('\n')
+        tagsVersion = self.stepVersion.currentText()
         errorList = []
         notFoundList = []
         successList = []
+
+        tagLogic.saveLastUsedTagPrefix(tagsVersion)
         for tagNumber in tagsList:
             print(tagNumber)
             tag = None
             try:
-                tag = tagLogic.createFullTag(tagNumber)
+                tag = tagLogic.createFullTag(tagNumber, tagsVersion)
             except Exception as err:
                 errorList.append((tagNumber, err))
             if tag:

--- a/dialog.py
+++ b/dialog.py
@@ -8,7 +8,7 @@ class OsceDialog(QDialog):
         self.setWindowTitle("UWorld Batch Unsuspend")
         self.layout = QVBoxLayout()
 
-        label1 = QLabel("Directions:\nEnter tags below. Each tag should be one line.\n\nPlease give Anki a few seconds to process.\n")
+        label1 = QLabel("Directions:\nUnsuspend multiple cards by entering their numbers below.\nNumbers should be on separate lines or comma separated.\nWhitespaces are removed.\n")
         self.layout.addWidget(label1)
 
         label2 = QLabel("Choose which version of cards you will be unsuspending.")
@@ -29,7 +29,7 @@ class OsceDialog(QDialog):
 
     def unsuspendCardsByTags(self):
 
-        tagsList = self.tags.toPlainText().strip().split('\n')
+        tagsList = getTagsFromText(self.tags.toPlainText())
         tagsVersion = self.stepVersion.currentText()
         errorList = []
         notFoundList = []
@@ -56,3 +56,10 @@ class OsceDialog(QDialog):
             messaging.showErrors(errorList, successList, notFoundList)
         else:
             messaging.showSuccess()
+
+def getTagsFromText(text: str) -> list[str]:
+    '''
+    Should accept strings that delimit by newline (\n) or comma (,).
+    Also makes sure to remove any whitespaces in between.
+    '''
+    return text.strip().replace('\n', ',').replace(' ', '').split(',')

--- a/meta.json
+++ b/meta.json
@@ -1,1 +1,0 @@
-{"disabled": false, "mod": 0, "conflicts": [], "max_point_version": 0, "min_point_version": 0, "branch_index": 0, "update_enabled": true}

--- a/tagLogic.py
+++ b/tagLogic.py
@@ -3,7 +3,14 @@ from aqt.utils import showInfo
 from aqt.qt import *
 import math
 
-def createFullTag (tagNumber):
+tagPrefixDict = {
+    'Step_1_v11': '#AK_Step1_v11::#UWorld::',
+    'Step_2_v11': '#AK_Step2_v11::#UWorld::',
+    # 'Step_1_v12': '#AK_Step1_v12::#UWorld::',
+    # 'Step_2_v12': '#AK_Step2_v12::#UWorld::',
+}
+
+def createFullTag (tagNumber, stepVersion):
 
     tagInt = None
     try:
@@ -11,7 +18,7 @@ def createFullTag (tagNumber):
     except ValueError:
         raise Exception('This is not a number. UWorld question IDs are numbers.')
 
-    tagPrefix = '#AK_Step1_v11::#UWorld::'
+    tagPrefix = tagPrefixDict[stepVersion] 
 
     if tagInt is None:
         raise Exception('Invalid tag. Tag should be a number.')
@@ -49,3 +56,28 @@ def unsuspendCardsByTag(tag) -> None:
         raise Exception('Found no matches by tag ' + tag + '. Perhaps that tag does not exist or is typed incorrectly.')
     else:
         mw.col.sched.unsuspendCards(ids)
+
+def loadLastUsedTagPrefix() -> str:
+
+    config = mw.addonManager.getConfig(__name__)
+    lastUsedTagPrefix = config['lastUsedTagPrefix']
+
+    return lastUsedTagPrefix
+
+def saveLastUsedTagPrefix(tagPrefix) -> None:
+
+    newConfig = {
+        'lastUsedTagPrefix': tagPrefix
+    } 
+
+    mw.addonManager.writeConfig(__name__, newConfig)
+
+def getLastUsedTagPrefixIndex() -> int:
+
+    lastUsedTagPrefix = loadLastUsedTagPrefix()
+
+    tagPrefixes = list(tagPrefixDict.keys())
+    if not lastUsedTagPrefix in tagPrefixes:
+        return 0
+    else:
+        return tagPrefixes.index(lastUsedTagPrefix)


### PR DESCRIPTION
Add ability to select between Step1_v11 and Step2_v11 when inputting UWorld card numbers.

Enablement for future use of v12 cards.

Also allowed UWorld QIDs to be separated by commas instead of just newlines