### PR TITLE
UWorld Subdirectory Traversal and Backport Python3.9 Typing for Compatibilty

### DIFF
--- a/dialog.py
+++ b/dialog.py
@@ -57,7 +57,7 @@ class OsceDialog(QDialog):
         else:
             messaging.showSuccess()
 
-def getTagsFromText(text: str) -> list[str]:
+def getTagsFromText(text: str):
     '''
     Should accept strings that delimit by newline (\n) or comma (,).
     Also makes sure to remove any whitespaces in between.

--- a/tagLogic.py
+++ b/tagLogic.py
@@ -34,27 +34,9 @@ def createFullTagV11 (tagNumber, stepVersion):
     elif tagInt > 0 and tagInt < 10:
         #convert single digit to two digit string
         return tagPrefix + '0-99::' + '0' + str(tagInt)
-    elif tagInt >= 10 and tagInt <= 99:
-        #add to 0-99 tag
-        return tagPrefix + '0-99::' + str(tagInt)
-    elif tagInt >= 100 and tagInt <= 999:
-        #add to 100-999 tag
-        lowerBound = math.floor(tagInt/100) * 100
-        upperBound = lowerBound + 99
-        return tagPrefix + '100-999::' + str(lowerBound) + '-' + str(upperBound) + '::' + str(tagInt)
-    elif tagInt >= 1000 and tagInt <= 9999:
-        #add to 1000 - 9999 tag
-        lowerBound = math.floor(tagInt/1000) * 1000
-        upperBound = lowerBound + 999
-        return tagPrefix + '1000-9999::' + str(lowerBound) + '-' + str(upperBound) + '::' + str(tagInt)
-    elif tagInt >= 10000 and tagInt <= 99999:
-        #add to 10000 - 99999 tag
-        lowerBound = math.floor(tagInt/1000) * 1000
-        upperBound = lowerBound + 999
-        return tagPrefix + '10000-99999::' + str(lowerBound) + '-' + str(upperBound) + '::' + str(tagInt)
     elif tagInt <= 106510:
         #v11 has 5 tags that are 100,000+, but go no higher than 106,510.
-        return tagPrefix + '10000-99999::22000+::' + str(tagInt)
+        return tagPrefix + '*::' + str(tagInt)
     else:
         raise Exception('This UWorld ID is too high! UWorld tags for v11 do not go above 106510.')
 
@@ -71,7 +53,7 @@ def createFullTagV12 (tagNumber, stepVersion):
     if tagInt is None:
         raise Exception('Invalid tag. Tag should be a number.') 
 
-    return tagPrefix + str(tagInt)
+    return tagPrefix + '*::' + str(tagInt)
 
 
 def unsuspendCardsByTag(tag) -> None:


### PR DESCRIPTION
Older versions of Anki (2.0.x) run on a lower version of Python, so we're removing Python3 typing so that it can compile and run.